### PR TITLE
chore(ci): update workflow for Laravel 10-12 and PHP 8.1-8.4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,19 +13,30 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2, 8.1]
-        laravel: [10.*]
-        stability: [prefer-lowest, prefer-stable]
+        php: [8.4, 8.3, 8.2, 8.1]
+        laravel: [12.*, 11.*, 10.*]
+        stability: [prefer-stable]
         include:
+          - laravel: 12.*
+            testbench: 10.*
+            carbon: ^3.0
+          - laravel: 11.*
+            testbench: 9.*
+            carbon: ^3.0
           - laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
+        exclude:
+          - laravel: 12.*
+            php: 8.1
+          - laravel: 11.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -49,3 +60,27 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/pest --ci
+
+  code-quality:
+    runs-on: ubuntu-latest
+    name: Code Quality
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          extensions: dom, curl, libxml, mbstring, zip
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction
+
+      - name: Check code style
+        run: vendor/bin/pint --test
+
+      - name: Run static analysis
+        run: vendor/bin/phpstan analyse --memory-limit=512M


### PR DESCRIPTION
Update GitHub Actions to test Laravel 10-12, PHP 8.1-8.4 and add code-quality job with PHPStan and Pint.