### PR TITLE
fix(ci): upgrade Pest v2 → v3, drop Laravel 10

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.4, 8.3, 8.2]
-        laravel: [12.*, 11.*, 10.*]
+        laravel: [12.*, 11.*]
         stability: [prefer-stable]
         include:
           - laravel: 12.*
@@ -23,9 +23,6 @@ jobs:
           - laravel: 11.*
             testbench: 9.*
             carbon: ^3.0
-          - laravel: 10.*
-            testbench: 8.*
-            carbon: ^2.63
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -20,17 +20,17 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^10.0|^11.0|^12.0"
+        "illuminate/contracts": "^11.0|^12.0"
     },
     "require-dev": {
-        "larastan/larastan": "2.x-dev",
+        "larastan/larastan": "^3.0",
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.8",
-        "orchestra/testbench": "^8.8",
-        "pestphp/pest": "^2.20",
-        "pestphp/pest-plugin-arch": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0",
-        "phpstan/phpstan": "1.12.x-dev"
+        "nunomaduro/collision": "^8.0",
+        "orchestra/testbench": "^9.0|^10.0",
+        "pestphp/pest": "^3.8",
+        "pestphp/pest-plugin-arch": "^3.0",
+        "pestphp/pest-plugin-laravel": "^3.0",
+        "phpstan/phpstan": "^2.1"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
     backupGlobals="false"
     bootstrap="vendor/autoload.php"
     colors="true"


### PR DESCRIPTION
## Summary

- **Upgrade Pest v2 → v3** stack to resolve dependency conflicts that cause all 18 CI test jobs to fail at `composer install`
- **Drop Laravel 10** support — Pest v3 requires PHPUnit 11 / Collision 8 which are incompatible with Laravel 10
- **Update PHPUnit schema** from 10.2 → 11.5 to match the new PHPUnit 11 used by Pest v3

## Problem

`pestphp/pest ^2.20` pulls in `nunomaduro/collision ^7.x` which requires Symfony Console 6, conflicting with Laravel 11+ (Symfony 7). Additionally, `pestphp/pest-plugin-laravel ^2.0` does not support Laravel 12.

## Changes

### `composer.json`
| Package | Before | After |
|---|---|---|
| `illuminate/contracts` | `^10.0\|^11.0\|^12.0` | `^11.0\|^12.0` |
| `nunomaduro/collision` | `^7.8` | `^8.0` |
| `orchestra/testbench` | `^8.8` | `^9.0\|^10.0` |
| `pestphp/pest` | `^2.20` | `^3.8` |
| `pestphp/pest-plugin-arch` | `^2.0` | `^3.0` |
| `pestphp/pest-plugin-laravel` | `^2.0` | `^3.0` |

### `.github/workflows/run-tests.yml`
- Removed Laravel 10 from matrix (and its testbench 8 / carbon ^2.63 include block)
- Result: 12 test jobs (3 PHP × 2 Laravel × 2 OS) + 1 code-quality = 13 total

### `phpunit.xml.dist`
- Schema URL updated from `phpunit.de/10.2/phpunit.xsd` → `phpunit.de/11.5/phpunit.xsd`

## Test plan

- [ ] All 123 tests pass locally with `vendor/bin/pest`
- [ ] `vendor/bin/pint --test` passes
- [ ] CI matrix runs 12 test jobs + 1 code-quality job successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)