### PR TITLE
Feature: Add artisan commands for date conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ The following format specifiers are supported for formatting dates:
 
 ```php
 // Convert English date to Nepali date (B.S.).
-toNepaliDate("1996-04-22") 
+toNepaliDate("1996-04-22")
 // Result: 2053-01-10
 
 // Convert Nepali date to English date (A.D.).
-toEnglishDate("2053-01-10") 
+toEnglishDate("2053-01-10")
 // Result: 1996-04-22
 ```
 
@@ -117,6 +117,24 @@ You can use the Blade directives directly in your views:
 @englishDate('2053-01-10', 'l, d F Y', 'en')
 {{-- Result: Monday, 22 April 1996 --}}
 ```
+
+
+## Artisan Commands
+
+Run quick conversions from the CLI:
+
+```bash
+php artisan nepali-date:convert --from=1996-04-22 --to=np
+php artisan nepali-date:today
+php artisan nepali-date:range --from=2080-01-01 --until=2080-01-05 --calendar=np --to=en
+```
+
+Common options:
+- `--format=` Output format (defaults to `config('nepali-date.default_format')`)
+- `--locale=` Output locale `en` or `np`
+- `--strict` Enable stricter date validation
+- `--json` Emit JSON output
+- `--timezone=` Timezone for `today`
 
 ## Getting Date as Array
 

--- a/src/Console/Commands/BaseNepaliDateCommand.php
+++ b/src/Console/Commands/BaseNepaliDateCommand.php
@@ -64,11 +64,13 @@ abstract class BaseNepaliDateCommand extends Command
             if ($escape) {
                 $pattern .= preg_quote($char, '/');
                 $escape = false;
+
                 continue;
             }
 
             if ($char === '\\') {
                 $escape = true;
+
                 continue;
             }
 
@@ -82,6 +84,7 @@ abstract class BaseNepaliDateCommand extends Command
                 $used[$name] = true;
                 $quantifier = $min === $max ? "{{$min}}" : "{{$min},{$max}}";
                 $pattern .= "(?P<{$name}>\\d{$quantifier})";
+
                 continue;
             }
 

--- a/src/Console/Commands/BaseNepaliDateCommand.php
+++ b/src/Console/Commands/BaseNepaliDateCommand.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Anuzpandey\LaravelNepaliDate\Console\Commands;
+
+use Anuzpandey\LaravelNepaliDate\LaravelNepaliDate;
+use Illuminate\Console\Command;
+use InvalidArgumentException;
+
+abstract class BaseNepaliDateCommand extends Command
+{
+    protected function normalizeCalendar(?string $value, string $optionName = 'calendar'): string
+    {
+        $value = strtolower(trim((string) $value));
+
+        if ($value === '') {
+            return 'en';
+        }
+
+        if (! in_array($value, ['en', 'np'], true)) {
+            throw new InvalidArgumentException("Invalid {$optionName} value [{$value}]. Use 'en' or 'np'.");
+        }
+
+        return $value;
+    }
+
+    protected function normalizeLocale(?string $value): string
+    {
+        $value = strtolower(trim((string) $value));
+
+        if ($value === '') {
+            return config('nepali-date.default_locale');
+        }
+
+        if (! in_array($value, ['en', 'np'], true)) {
+            throw new InvalidArgumentException("Invalid locale value [{$value}]. Use 'en' or 'np'.");
+        }
+
+        return $value;
+    }
+
+    protected function resolveFormat(?string $value): string
+    {
+        return $value ?: config('nepali-date.default_format');
+    }
+
+    protected function parseDateString(string $date, string $format): array
+    {
+        $tokens = [
+            'Y' => ['year', 4, 4],
+            'm' => ['month', 2, 2],
+            'n' => ['month', 1, 2],
+            'd' => ['day', 2, 2],
+            'j' => ['day', 1, 2],
+        ];
+
+        $pattern = '';
+        $used = [];
+        $escape = false;
+        $length = strlen($format);
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = $format[$i];
+
+            if ($escape) {
+                $pattern .= preg_quote($char, '/');
+                $escape = false;
+                continue;
+            }
+
+            if ($char === '\\') {
+                $escape = true;
+                continue;
+            }
+
+            if (array_key_exists($char, $tokens)) {
+                [$name, $min, $max] = $tokens[$char];
+
+                if (isset($used[$name])) {
+                    throw new InvalidArgumentException("Input format cannot repeat [{$name}] token.");
+                }
+
+                $used[$name] = true;
+                $quantifier = $min === $max ? "{{$min}}" : "{{$min},{$max}}";
+                $pattern .= "(?P<{$name}>\\d{$quantifier})";
+                continue;
+            }
+
+            if (ctype_alpha($char)) {
+                throw new InvalidArgumentException("Unsupported input format token [{$char}].");
+            }
+
+            $pattern .= preg_quote($char, '/');
+        }
+
+        $pattern = '/^'.$pattern.'$/';
+
+        if (! preg_match($pattern, $date, $matches)) {
+            throw new InvalidArgumentException('Input date does not match the provided format.');
+        }
+
+        if (! isset($matches['year'], $matches['month'], $matches['day'])) {
+            throw new InvalidArgumentException('Input format must include Y, m, and d tokens.');
+        }
+
+        return [
+            'year' => (int) $matches['year'],
+            'month' => (int) $matches['month'],
+            'day' => (int) $matches['day'],
+        ];
+    }
+
+    protected function normalizeDate(int $year, int $month, int $day): string
+    {
+        return sprintf('%04d-%02d-%02d', $year, $month, $day);
+    }
+
+    protected function validateDateRange(string $calendar, int $year, int $month, int $day): void
+    {
+        if ($calendar === 'en') {
+            if ($year < 1944 || $year > 2033) {
+                throw new InvalidArgumentException('Date is out of range. Please provide date between 1944-01-01 to 2033-12-31');
+            }
+
+            if ($month < 1 || $month > 12) {
+                throw new InvalidArgumentException('Month is out of range. Please provide month between 1-12');
+            }
+
+            if ($day < 1 || $day > 31) {
+                throw new InvalidArgumentException('Day is out of range. Please provide day between 1-31');
+            }
+
+            return;
+        }
+
+        if ($year < 2000 || $year > 2089) {
+            throw new InvalidArgumentException('Date is out of range. Please provide date between 2000 to 2089');
+        }
+
+        if ($month < 1 || $month > 12) {
+            throw new InvalidArgumentException('Month is out of range. Please provide month between 1-12');
+        }
+
+        if ($day < 1 || $day > 32) {
+            throw new InvalidArgumentException('Day is out of range. Please provide day between 1-32');
+        }
+    }
+
+    protected function validateStrictDate(string $calendar, int $year, int $month, int $day): void
+    {
+        if ($calendar === 'en') {
+            if (! checkdate($month, $day, $year)) {
+                throw new InvalidArgumentException("Invalid day for {$year}-".sprintf('%02d', $month));
+            }
+
+            return;
+        }
+
+        $daysInMonth = LaravelNepaliDate::daysInMonth($month, $year);
+
+        if ($day > $daysInMonth) {
+            throw new InvalidArgumentException("Invalid day for {$year}-".sprintf('%02d', $month).". Max is {$daysInMonth}.");
+        }
+    }
+
+    protected function parseInputDate(string $date, string $format, string $calendar, bool $strict): array
+    {
+        $parts = $this->parseDateString($date, $format);
+        $year = $parts['year'];
+        $month = $parts['month'];
+        $day = $parts['day'];
+
+        $this->validateDateRange($calendar, $year, $month, $day);
+
+        if ($strict) {
+            $this->validateStrictDate($calendar, $year, $month, $day);
+        }
+
+        return [$year, $month, $day, $this->normalizeDate($year, $month, $day)];
+    }
+
+    protected function formatEnglishDate(string $englishDate, string $format, string $locale): string
+    {
+        if ($format === 'Y-m-d' && $locale === 'en') {
+            return $englishDate;
+        }
+
+        $nepaliDate = LaravelNepaliDate::from($englishDate)->toNepaliDate('Y-m-d', 'en');
+
+        return LaravelNepaliDate::from($nepaliDate)->toEnglishDate($format, $locale);
+    }
+}

--- a/src/Console/Commands/ConvertNepaliDateCommand.php
+++ b/src/Console/Commands/ConvertNepaliDateCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Anuzpandey\LaravelNepaliDate\Console\Commands;
+
+use Anuzpandey\LaravelNepaliDate\LaravelNepaliDate;
+use InvalidArgumentException;
+use RuntimeException;
+
+class ConvertNepaliDateCommand extends BaseNepaliDateCommand
+{
+    protected $signature = 'nepali-date:convert
+        {--from= : Input date (required)}
+        {--to= : Target calendar en|np (required)}
+        {--input-format=Y-m-d : Input date format}
+        {--calendar=en : Input calendar en|np}
+        {--format= : Output format}
+        {--locale= : Output locale en|np}
+        {--strict : Enable strict date validation}
+        {--json : Emit machine-readable JSON output}
+        {--timezone= : Timezone for datetime parsing}';
+
+    protected $description = 'Convert a single date between Nepali (BS) and English (AD) calendars.';
+
+    public function handle(): int
+    {
+        try {
+            $from = $this->option('from');
+            $targetCalendar = $this->normalizeCalendar($this->option('to'), 'to');
+            $inputCalendar = $this->normalizeCalendar($this->option('calendar'), 'calendar');
+
+            if (! $from) {
+                throw new InvalidArgumentException('The --from option is required.');
+            }
+
+            if ($inputCalendar === $targetCalendar) {
+                throw new InvalidArgumentException('Input and output calendars must be different.');
+            }
+
+            $format = $this->resolveFormat($this->option('format'));
+            $locale = $this->normalizeLocale($this->option('locale'));
+            $inputFormat = $this->option('input-format') ?: 'Y-m-d';
+            $strict = (bool) $this->option('strict');
+
+            [$year, $month, $day, $inputDate] = $this->parseInputDate($from, $inputFormat, $inputCalendar, $strict);
+
+            if ($targetCalendar === 'np') {
+                $outputDate = LaravelNepaliDate::from($inputDate)->toNepaliDate('Y-m-d', 'en');
+                $formatted = LaravelNepaliDate::from($inputDate)->toNepaliDate($format, $locale);
+            } else {
+                $outputDate = LaravelNepaliDate::from($inputDate)->toEnglishDate('Y-m-d', 'en');
+                $formatted = LaravelNepaliDate::from($inputDate)->toEnglishDate($format, $locale);
+            }
+
+            if ($this->option('json')) {
+                $payload = [
+                    'input' => $inputDate,
+                    'input_calendar' => $inputCalendar,
+                    'output' => $outputDate,
+                    'output_calendar' => $targetCalendar,
+                    'formatted' => $formatted,
+                    'format' => $format,
+                    'locale' => $locale,
+                ];
+
+                $this->line(json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+                return self::SUCCESS;
+            }
+
+            if ($this->option('quiet')) {
+                $this->line($outputDate);
+
+                return self::SUCCESS;
+            }
+
+            $this->line("Input: {$inputDate} ({$inputCalendar})");
+            $this->line("Output: {$outputDate} ({$targetCalendar})");
+            $this->line("Formatted: {$formatted}");
+
+            return self::SUCCESS;
+        } catch (InvalidArgumentException | RuntimeException $exception) {
+            $this->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+}

--- a/src/Console/Commands/ConvertNepaliDateCommand.php
+++ b/src/Console/Commands/ConvertNepaliDateCommand.php
@@ -78,7 +78,7 @@ class ConvertNepaliDateCommand extends BaseNepaliDateCommand
             $this->line("Formatted: {$formatted}");
 
             return self::SUCCESS;
-        } catch (InvalidArgumentException | RuntimeException $exception) {
+        } catch (InvalidArgumentException|RuntimeException $exception) {
             $this->error($exception->getMessage());
 
             return self::FAILURE;

--- a/src/Console/Commands/RangeNepaliDateCommand.php
+++ b/src/Console/Commands/RangeNepaliDateCommand.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Anuzpandey\LaravelNepaliDate\Console\Commands;
+
+use Anuzpandey\LaravelNepaliDate\LaravelNepaliDate;
+use DateInterval;
+use DateTimeImmutable;
+use InvalidArgumentException;
+use RuntimeException;
+
+class RangeNepaliDateCommand extends BaseNepaliDateCommand
+{
+    protected $signature = 'nepali-date:range
+        {--from= : Start date (required)}
+        {--until= : End date (required)}
+        {--end= : Alias for --until}
+        {--to= : Target calendar en|np}
+        {--calendar=en : Input calendar en|np}
+        {--format= : Output format}
+        {--locale= : Output locale en|np}
+        {--limit=366 : Max number of days to output}
+        {--strict : Enable strict date validation}
+        {--json : Emit machine-readable JSON output}
+        {--timezone= : Timezone for datetime parsing}';
+
+    protected $description = 'List a range of converted dates between calendars.';
+
+    public function handle(): int
+    {
+        try {
+            $from = $this->option('from');
+            $until = $this->option('until') ?: $this->option('end');
+
+            if (! $from) {
+                throw new InvalidArgumentException('The --from option is required.');
+            }
+
+            if (! $until) {
+                throw new InvalidArgumentException('The --until option is required.');
+            }
+
+            $inputCalendar = $this->normalizeCalendar($this->option('calendar'), 'calendar');
+            $targetCalendar = $this->option('to')
+                ? $this->normalizeCalendar($this->option('to'), 'to')
+                : ($inputCalendar === 'en' ? 'np' : 'en');
+
+            if ($inputCalendar === $targetCalendar) {
+                throw new InvalidArgumentException('Input and output calendars must be different.');
+            }
+
+            $format = $this->resolveFormat($this->option('format'));
+            $locale = $this->normalizeLocale($this->option('locale'));
+            $limit = (int) ($this->option('limit') ?? 366);
+            $strict = (bool) $this->option('strict');
+
+            if ($limit < 1) {
+                throw new InvalidArgumentException('The --limit option must be at least 1.');
+            }
+
+            if ($inputCalendar === 'en') {
+                [$startYear, $startMonth, $startDay, $startRaw] = $this->parseInputDate($from, 'Y-m-d', $inputCalendar, $strict);
+                [$endYear, $endMonth, $endDay, $endRaw] = $this->parseInputDate($until, 'Y-m-d', $inputCalendar, $strict);
+
+                $startDate = new DateTimeImmutable($this->normalizeDate($startYear, $startMonth, $startDay));
+                $endDate = new DateTimeImmutable($this->normalizeDate($endYear, $endMonth, $endDay));
+            } else {
+                [$startYear, $startMonth, $startDay, $startRaw] = $this->parseInputDate($from, 'Y-m-d', $inputCalendar, $strict);
+                [$endYear, $endMonth, $endDay, $endRaw] = $this->parseInputDate($until, 'Y-m-d', $inputCalendar, $strict);
+
+                $startEnglish = LaravelNepaliDate::from($this->normalizeDate($startYear, $startMonth, $startDay))
+                    ->toEnglishDate('Y-m-d', 'en');
+                $endEnglish = LaravelNepaliDate::from($this->normalizeDate($endYear, $endMonth, $endDay))
+                    ->toEnglishDate('Y-m-d', 'en');
+
+                $startDate = new DateTimeImmutable($startEnglish);
+                $endDate = new DateTimeImmutable($endEnglish);
+            }
+
+            $diff = $startDate->diff($endDate);
+            $days = (int) $diff->format('%r%a');
+
+            if ($days < 0) {
+                throw new InvalidArgumentException('The --from date must be on or before the --until date.');
+            }
+
+            $totalDays = $days + 1;
+
+            if ($totalDays > $limit) {
+                throw new InvalidArgumentException("Range spans {$totalDays} days which exceeds the limit of {$limit}. Use --limit to increase.");
+            }
+
+            $items = [];
+            $current = $startDate;
+
+            for ($i = 0; $i < $totalDays; $i++) {
+                $englishDate = $current->format('Y-m-d');
+
+                if ($inputCalendar === 'en') {
+                    $inputDate = $englishDate;
+                } else {
+                    $inputDate = LaravelNepaliDate::from($englishDate)->toNepaliDate('Y-m-d', 'en');
+                }
+
+                if ($targetCalendar === 'np') {
+                    $outputDate = LaravelNepaliDate::from($englishDate)->toNepaliDate('Y-m-d', 'en');
+                    $formatted = LaravelNepaliDate::from($englishDate)->toNepaliDate($format, $locale);
+                } else {
+                    $outputDate = $englishDate;
+                    $formatted = $this->formatEnglishDate($englishDate, $format, $locale);
+                }
+
+                $items[] = [
+                    'input' => $inputDate,
+                    'output' => $outputDate,
+                    'formatted' => $formatted,
+                ];
+
+                $current = $current->add(new DateInterval('P1D'));
+            }
+
+            if ($this->option('json')) {
+                $payload = [
+                    'range' => [
+                        'from' => $from,
+                        'until' => $until,
+                        'calendar' => $inputCalendar,
+                        'output_calendar' => $targetCalendar,
+                    ],
+                    'format' => $format,
+                    'locale' => $locale,
+                    'items' => $items,
+                ];
+
+                $this->line(json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+                return self::SUCCESS;
+            }
+
+            foreach ($items as $item) {
+                if ($this->option('quiet')) {
+                    $this->line("{$item['input']} -> {$item['output']}");
+                } else {
+                    $this->line("{$item['input']} -> {$item['output']} | formatted: {$item['formatted']}");
+                }
+            }
+
+            return self::SUCCESS;
+        } catch (InvalidArgumentException | RuntimeException $exception) {
+            $this->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+}

--- a/src/Console/Commands/RangeNepaliDateCommand.php
+++ b/src/Console/Commands/RangeNepaliDateCommand.php
@@ -145,7 +145,7 @@ class RangeNepaliDateCommand extends BaseNepaliDateCommand
             }
 
             return self::SUCCESS;
-        } catch (InvalidArgumentException | RuntimeException $exception) {
+        } catch (InvalidArgumentException|RuntimeException $exception) {
             $this->error($exception->getMessage());
 
             return self::FAILURE;

--- a/src/Console/Commands/TodayNepaliDateCommand.php
+++ b/src/Console/Commands/TodayNepaliDateCommand.php
@@ -76,7 +76,7 @@ class TodayNepaliDateCommand extends BaseNepaliDateCommand
             $this->line("Formatted (np): {$nepaliFormatted}");
 
             return self::SUCCESS;
-        } catch (InvalidArgumentException | RuntimeException $exception) {
+        } catch (InvalidArgumentException|RuntimeException $exception) {
             $this->error($exception->getMessage());
 
             return self::FAILURE;

--- a/src/Console/Commands/TodayNepaliDateCommand.php
+++ b/src/Console/Commands/TodayNepaliDateCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Anuzpandey\LaravelNepaliDate\Console\Commands;
+
+use Anuzpandey\LaravelNepaliDate\LaravelNepaliDate;
+use Carbon\Carbon;
+use InvalidArgumentException;
+use RuntimeException;
+
+class TodayNepaliDateCommand extends BaseNepaliDateCommand
+{
+    protected $signature = 'nepali-date:today
+        {--calendar=en : Primary output calendar en|np}
+        {--format= : Output format}
+        {--locale= : Output locale en|np}
+        {--strict : Enable strict date validation}
+        {--json : Emit machine-readable JSON output}
+        {--timezone= : Timezone for today output}';
+
+    protected $description = 'Show today in both Nepali (BS) and English (AD) calendars.';
+
+    public function handle(): int
+    {
+        try {
+            $primaryCalendar = $this->normalizeCalendar($this->option('calendar'), 'calendar');
+            $format = $this->resolveFormat($this->option('format'));
+            $locale = $this->normalizeLocale($this->option('locale'));
+            $timezone = $this->option('timezone') ?: config('app.timezone');
+
+            $today = Carbon::now($timezone ?? 'UTC');
+            $englishDate = $today->format('Y-m-d');
+
+            $nepaliDate = LaravelNepaliDate::from($englishDate)->toNepaliDate('Y-m-d', 'en');
+
+            $englishFormatted = $this->formatEnglishDate($englishDate, $format, $locale);
+            $nepaliFormatted = LaravelNepaliDate::from($englishDate)->toNepaliDate($format, $locale);
+
+            $primaryRaw = $primaryCalendar === 'en' ? $englishDate : $nepaliDate;
+
+            if ($this->option('json')) {
+                $payload = [
+                    'timezone' => $timezone ?? 'UTC',
+                    'format' => $format,
+                    'locale' => $locale,
+                    'en' => [
+                        'raw' => $englishDate,
+                        'formatted' => $englishFormatted,
+                    ],
+                    'np' => [
+                        'raw' => $nepaliDate,
+                        'formatted' => $nepaliFormatted,
+                    ],
+                    'primary_calendar' => $primaryCalendar,
+                ];
+
+                $this->line(json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+                return self::SUCCESS;
+            }
+
+            if ($this->option('quiet')) {
+                $this->line($primaryRaw);
+
+                return self::SUCCESS;
+            }
+
+            if ($primaryCalendar === 'en') {
+                $this->line("Today (en): {$englishDate}");
+                $this->line("Today (np): {$nepaliDate}");
+            } else {
+                $this->line("Today (np): {$nepaliDate}");
+                $this->line("Today (en): {$englishDate}");
+            }
+
+            $this->line("Formatted (en): {$englishFormatted}");
+            $this->line("Formatted (np): {$nepaliFormatted}");
+
+            return self::SUCCESS;
+        } catch (InvalidArgumentException | RuntimeException $exception) {
+            $this->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+}

--- a/src/LaravelNepaliDateServiceProvider.php
+++ b/src/LaravelNepaliDateServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace Anuzpandey\LaravelNepaliDate;
 
+use Anuzpandey\LaravelNepaliDate\Console\Commands\ConvertNepaliDateCommand;
+use Anuzpandey\LaravelNepaliDate\Console\Commands\RangeNepaliDateCommand;
+use Anuzpandey\LaravelNepaliDate\Console\Commands\TodayNepaliDateCommand;
 use Anuzpandey\LaravelNepaliDate\Directives\NepaliDateDirective;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -11,7 +14,12 @@ class LaravelNepaliDateServiceProvider extends PackageServiceProvider
     public function configurePackage(Package $package): void
     {
         $package->name('laravel-nepali-date')
-            ->hasConfigFile();
+            ->hasConfigFile()
+            ->hasCommands([
+                ConvertNepaliDateCommand::class,
+                TodayNepaliDateCommand::class,
+                RangeNepaliDateCommand::class,
+            ]);
     }
 
     public function boot(): void

--- a/tests/ArtisanCommandsTest.php
+++ b/tests/ArtisanCommandsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Artisan;
+
+it('converts dates via artisan command', function () {
+    $this->artisan('nepali-date:convert', [
+        '--from' => '1996-04-22',
+        '--to' => 'np',
+        '--format' => 'l, d F Y',
+        '--locale' => 'np',
+    ])
+        ->expectsOutput('Input: 1996-04-22 (en)')
+        ->expectsOutput('Output: 2053-01-10 (np)')
+        ->expectsOutput('Formatted: सोमबार, १० वैशाख २०५३')
+        ->assertExitCode(0);
+});
+
+it('outputs json for convert command', function () {
+    Artisan::call('nepali-date:convert', [
+        '--from' => '1996-04-22',
+        '--to' => 'np',
+        '--format' => 'l, d F Y',
+        '--locale' => 'np',
+        '--json' => true,
+    ]);
+
+    $payload = json_decode(Artisan::output(), true);
+
+    expect($payload)->toMatchArray([
+        'input' => '1996-04-22',
+        'input_calendar' => 'en',
+        'output' => '2053-01-10',
+        'output_calendar' => 'np',
+        'formatted' => 'सोमबार, १० वैशाख २०५३',
+        'format' => 'l, d F Y',
+        'locale' => 'np',
+    ]);
+});
+
+it('shows today in both calendars', function () {
+    Carbon::setTestNow(Carbon::create(1996, 4, 22, 0, 0, 0, 'UTC'));
+    config()->set('app.timezone', 'UTC');
+
+    $this->artisan('nepali-date:today', [
+        '--format' => 'Y-m-d',
+        '--locale' => 'np',
+    ])
+        ->expectsOutput('Today (en): 1996-04-22')
+        ->expectsOutput('Today (np): 2053-01-10')
+        ->expectsOutput('Formatted (en): १९९६-०४-२२')
+        ->expectsOutput('Formatted (np): २०५३-०१-१०')
+        ->assertExitCode(0);
+
+    Carbon::setTestNow();
+});
+
+it('lists a range of converted dates', function () {
+    $this->artisan('nepali-date:range', [
+        '--from' => '2080-01-01',
+        '--until' => '2080-01-03',
+        '--calendar' => 'np',
+        '--to' => 'en',
+        '--format' => 'Y-m-d',
+        '--locale' => 'en',
+    ])
+        ->expectsOutput('2080-01-01 -> 2023-04-14 | formatted: 2023-04-14')
+        ->expectsOutput('2080-01-02 -> 2023-04-15 | formatted: 2023-04-15')
+        ->expectsOutput('2080-01-03 -> 2023-04-16 | formatted: 2023-04-16')
+        ->assertExitCode(0);
+});


### PR DESCRIPTION
- Added nepali-date:convert, nepali-date:today, and nepali-date:range commands.
- Introduced shared parsing/validation and JSON output support.
- Added tests covering command output and range behavior.
- Documented new artisan commands with examples.
- Listed common CLI options for formatting, locale, strict, json, and timezone.