### PR TITLE
feat: add now/today helpers with datetime conversion and time token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ php artisan vendor:publish --tag="nepali-date-config"
 ## Usage
 
 ```php
-use Carbon\Carbon;
 use Anuzpandey\LaravelNepaliDate\LaravelNepaliDate;
 
 $engDate = '1996-04-22';

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ php artisan vendor:publish --tag="nepali-date-config"
 ## Usage
 
 ```php
+use Carbon\Carbon;
+use Anuzpandey\LaravelNepaliDate\LaravelNepaliDate;
+
 $engDate = '1996-04-22';
 LaravelNepaliDate::from($engDate)->toNepaliDate();
 // Result: 2053-01-10
@@ -57,6 +60,102 @@ LaravelNepaliDate::daysInYear(2053);
 // Result: 365
 ```
 
+## Flexible Inputs
+
+`LaravelNepaliDate::from()` accepts multiple input types:
+
+- Date string (default format `Y-m-d`)
+- Date string with custom format
+- `DateTimeInterface` / Carbon (English calendar only)
+- Unix timestamp as `int`
+- Unix timestamp as numeric `string`
+- Array input with `year`, `month`, `day` (optional `hour`, `minute`, `second`)
+
+```php
+use Carbon\Carbon;
+use Anuzpandey\LaravelNepaliDate\LaravelNepaliDate;
+
+LaravelNepaliDate::from('1996-04-22')->toNepaliDate();
+LaravelNepaliDate::from('22/04/1996', format: 'd/m/Y')->toNepaliDate();
+
+LaravelNepaliDate::from(Carbon::parse('1996-04-22'))->toNepaliDate();
+LaravelNepaliDate::from(829632000)->toNepaliDate();
+LaravelNepaliDate::from('829632000')->toNepaliDate(); // numeric string timestamp
+
+LaravelNepaliDate::from([
+    'year' => 1996,
+    'month' => 4,
+    'day' => 22,
+    'hour' => 12,
+    'minute' => 30,
+    'second' => 15,
+])->toNepaliDateTime();
+```
+
+You can also use `parse()` when passing options as an array:
+
+```php
+LaravelNepaliDate::parse('22/04/1996', [
+    'format' => 'd/m/Y',
+    'calendar' => 'en',
+    'strict' => true,
+])->toNepaliDate();
+```
+
+## Strict Validation
+
+Enable strict validation per-call:
+
+```php
+LaravelNepaliDate::from('2023-02-30', strict: true)->toNepaliDate();
+// throws InvalidDateException
+```
+
+Or validate directly:
+
+```php
+LaravelNepaliDate::validateEnglish('2024-02-29'); // true
+LaravelNepaliDate::validateEnglish('2023-02-29'); // false or throws
+
+LaravelNepaliDate::validateNepali('2081-02-32'); // true if valid in BS calendar data
+LaravelNepaliDate::validateNepali('2081-02-33'); // false or throws
+```
+
+You can set package-wide defaults in `config/nepali-date.php`:
+
+```php
+'validation' => [
+    'strict' => false,
+    'throw_on_invalid' => true,
+],
+```
+
+## Now, Today, and DateTime Conversion
+
+```php
+use Anuzpandey\LaravelNepaliDate\LaravelNepaliDate;
+
+// Current date helpers
+LaravelNepaliDate::today()->toNepaliDate();
+LaravelNepaliDate::today('np')->toEnglishDate();
+
+LaravelNepaliDate::now()->toNepaliDateTime();
+LaravelNepaliDate::now('np')->toEnglishDateTime();
+
+// Preserve time while converting calendars
+LaravelNepaliDate::from('1996-04-22 12:30:15', format: 'Y-m-d H:i:s')
+    ->toNepaliDateTime('Y-m-d H:i:s');
+// Result: 2053-01-10 12:30:15
+
+LaravelNepaliDate::from('2053-01-10 12:30:15', format: 'Y-m-d H:i:s', calendar: 'np')
+    ->toEnglishDateTime('Y-m-d H:i:s');
+// Result: 1996-04-22 12:30:15
+```
+
+Notes:
+- If input has no time component, time defaults to `00:00:00`.
+- Locale formatting applies to the date portion; time remains numeric.
+
 ## Format Specifiers
 
 The following format specifiers are supported for formatting dates:
@@ -72,6 +171,14 @@ The following format specifiers are supported for formatting dates:
 - `D` - Day in three letters (Sun-Sat/आइत-शनि)
 - `l` - Day in full name (Sunday-Saturday/आइतबार-शनिबार)
 - `S` - Day in two letters (st, nd, rd, th)
+- `H` - Hour in 24-hour format with leading zero (00-23)
+- `G` - Hour in 24-hour format without leading zero (0-23)
+- `h` - Hour in 12-hour format with leading zero (01-12)
+- `g` - Hour in 12-hour format without leading zero (1-12)
+- `i` - Minutes with leading zero (00-59)
+- `s` - Seconds with leading zero (00-59)
+- `a` - Lowercase meridiem (`am` or `pm`)
+- `A` - Uppercase meridiem (`AM` or `PM`)
 
 ## Extending Carbon with NepaliDateMixin
 > **Note:** This feature has been deprecated as Carbon doesn't support the months having more than 31 days. This feature has been removed from version 2.0.0.

--- a/src/LaravelNepaliDate.php
+++ b/src/LaravelNepaliDate.php
@@ -29,6 +29,12 @@ class LaravelNepaliDate
 
     private ?string $inputDate = null;
 
+    private int $hour = 0;
+
+    private int $minute = 0;
+
+    private int $second = 0;
+
     public function __construct(
         public int|string $year,
         public int|string $month,
@@ -49,11 +55,12 @@ class LaravelNepaliDate
         $calendar = self::normalizeCalendar($calendar);
         $strict = $strict ?? (bool) config('nepali-date.validation.strict', false);
 
-        [$year, $month, $day, $inputDate] = self::parseInput($input, $format, $calendar);
+        [$year, $month, $day, $hour, $minute, $second, $inputDate] = self::parseInput($input, $format, $calendar);
 
         $instance = new self($year, $month, $day, $strict);
         $instance->inputFormat = $format;
         $instance->inputDate = $inputDate;
+        $instance->setTime($hour, $minute, $second);
 
         return $instance;
     }
@@ -68,6 +75,37 @@ class LaravelNepaliDate
         }
 
         return self::from($input, $format, $calendar, $strict);
+    }
+
+    public static function today(string $calendar = 'en'): self
+    {
+        $calendar = self::normalizeCalendar($calendar);
+        $timezone = new DateTimeZone(config('app.timezone', 'UTC'));
+        $now = new DateTimeImmutable('now', $timezone);
+
+        if ($calendar === 'en') {
+            return self::from($now->format('Y-m-d 00:00:00'), 'Y-m-d H:i:s', 'en');
+        }
+
+        $nepaliDate = self::from($now->format('Y-m-d'))->toNepaliDate('Y-m-d', 'en');
+
+        return self::from($nepaliDate.' 00:00:00', 'Y-m-d H:i:s', 'np');
+    }
+
+    public static function now(string $calendar = 'en'): self
+    {
+        $calendar = self::normalizeCalendar($calendar);
+        $timezone = new DateTimeZone(config('app.timezone', 'UTC'));
+        $now = new DateTimeImmutable('now', $timezone);
+
+        if ($calendar === 'en') {
+            return self::from($now->format('Y-m-d H:i:s'), 'Y-m-d H:i:s', 'en');
+        }
+
+        $nepaliDate = self::from($now->format('Y-m-d'))->toNepaliDate('Y-m-d', 'en');
+        $time = $now->format('H:i:s');
+
+        return self::from($nepaliDate.' '.$time, 'Y-m-d H:i:s', 'np');
     }
 
     public static function validateEnglish(string|DateTimeInterface $date, string $format = 'Y-m-d'): bool
@@ -261,7 +299,11 @@ class LaravelNepaliDate
             $month = (int) $input->format('m');
             $day = (int) $input->format('d');
 
-            return [$year, $month, $day, $input->format('Y-m-d')];
+            $hour = (int) $input->format('H');
+            $minute = (int) $input->format('i');
+            $second = (int) $input->format('s');
+
+            return [$year, $month, $day, $hour, $minute, $second, $input->format('Y-m-d H:i:s')];
         }
 
         if (is_int($input)) {
@@ -276,7 +318,11 @@ class LaravelNepaliDate
             $month = (int) $date->format('m');
             $day = (int) $date->format('d');
 
-            return [$year, $month, $day, $date->format('Y-m-d')];
+            $hour = (int) $date->format('H');
+            $minute = (int) $date->format('i');
+            $second = (int) $date->format('s');
+
+            return [$year, $month, $day, $hour, $minute, $second, $date->format('Y-m-d H:i:s')];
         }
 
         if (is_array($input)) {
@@ -287,8 +333,12 @@ class LaravelNepaliDate
             $year = (int) $input['year'];
             $month = (int) $input['month'];
             $day = (int) $input['day'];
+            $hour = (int) ($input['hour'] ?? 0);
+            $minute = (int) ($input['minute'] ?? 0);
+            $second = (int) ($input['second'] ?? 0);
+            self::assertTimeComponents($hour, $minute, $second);
 
-            return [$year, $month, $day, sprintf('%04d-%02d-%02d', $year, $month, $day)];
+            return [$year, $month, $day, $hour, $minute, $second, sprintf('%04d-%02d-%02d %02d:%02d:%02d', $year, $month, $day, $hour, $minute, $second)];
         }
 
         if (! is_string($input)) {
@@ -312,13 +362,17 @@ class LaravelNepaliDate
             $month = (int) $date->format('m');
             $day = (int) $date->format('d');
 
-            return [$year, $month, $day, $date->format('Y-m-d')];
+            $hour = (int) $date->format('H');
+            $minute = (int) $date->format('i');
+            $second = (int) $date->format('s');
+
+            return [$year, $month, $day, $hour, $minute, $second, $date->format('Y-m-d H:i:s')];
         }
 
         try {
-            [$year, $month, $day] = self::parseDateComponents($input, $format);
+            [$year, $month, $day, $hour, $minute, $second] = self::parseDateTimeComponents($input, $format);
 
-            return [$year, $month, $day, $input];
+            return [$year, $month, $day, $hour, $minute, $second, $input];
         } catch (InvalidDateException $exception) {
             if (! ctype_digit($input)) {
                 throw $exception;
@@ -345,13 +399,22 @@ class LaravelNepaliDate
             $month = (int) $date->format('m');
             $day = (int) $date->format('d');
 
-            return [$year, $month, $day, $date->format('Y-m-d')];
-        }
+            $hour = (int) $date->format('H');
+            $minute = (int) $date->format('i');
+            $second = (int) $date->format('s');
 
-        return [$year, $month, $day, $input];
+            return [$year, $month, $day, $hour, $minute, $second, $date->format('Y-m-d H:i:s')];
+        }
     }
 
     protected static function parseDateComponents(string $date, string $format): array
+    {
+        [$year, $month, $day] = self::parseDateTimeComponents($date, $format);
+
+        return [$year, $month, $day];
+    }
+
+    protected static function parseDateTimeComponents(string $date, string $format): array
     {
         $tokens = [
             'Y' => ['year', 4, 4],
@@ -359,6 +422,9 @@ class LaravelNepaliDate
             'n' => ['month', 1, 2],
             'd' => ['day', 2, 2],
             'j' => ['day', 1, 2],
+            'H' => ['hour', 2, 2],
+            'i' => ['minute', 2, 2],
+            's' => ['second', 2, 2],
         ];
 
         $pattern = '';
@@ -413,10 +479,55 @@ class LaravelNepaliDate
             throw InvalidDateException::forDate('Input format must include Y, m, and d tokens.', ['format' => $format]);
         }
 
+        $hour = isset($matches['hour']) ? (int) $matches['hour'] : 0;
+        $minute = isset($matches['minute']) ? (int) $matches['minute'] : 0;
+        $second = isset($matches['second']) ? (int) $matches['second'] : 0;
+        self::assertTimeComponents($hour, $minute, $second);
+
         return [
             (int) $matches['year'],
             (int) $matches['month'],
             (int) $matches['day'],
+            $hour,
+            $minute,
+            $second,
+        ];
+    }
+
+    protected static function assertTimeComponents(int $hour, int $minute, int $second): void
+    {
+        if ($hour < 0 || $hour > 23 || $minute < 0 || $minute > 59 || $second < 0 || $second > 59) {
+            throw InvalidDateException::forDate('Time is out of range. Please provide valid time between 00:00:00 and 23:59:59.', [
+                'hour' => $hour,
+                'minute' => $minute,
+                'second' => $second,
+            ]);
+        }
+    }
+
+    protected function setTime(int $hour, int $minute, int $second): void
+    {
+        self::assertTimeComponents($hour, $minute, $second);
+
+        $this->hour = $hour;
+        $this->minute = $minute;
+        $this->second = $second;
+    }
+
+    protected function getTimeFormatData(): array
+    {
+        $hour12 = $this->hour % 12;
+        $hour12 = $hour12 === 0 ? 12 : $hour12;
+
+        return [
+            'H' => sprintf('%02d', $this->hour),
+            'G' => (string) $this->hour,
+            'h' => sprintf('%02d', $hour12),
+            'g' => (string) $hour12,
+            'i' => sprintf('%02d', $this->minute),
+            's' => sprintf('%02d', $this->second),
+            'a' => $this->hour < 12 ? 'am' : 'pm',
+            'A' => $this->hour < 12 ? 'AM' : 'PM',
         ];
     }
 }

--- a/src/Traits/EnglishDateTrait.php
+++ b/src/Traits/EnglishDateTrait.php
@@ -73,6 +73,22 @@ trait EnglishDateTrait
         );
     }
 
+    public function toEnglishDateTime(string $format = 'Y-m-d H:i:s', ?string $locale = null): string
+    {
+        $locale = $locale ?? config('nepali-date.default_locale');
+        $this->assertNepaliDate();
+
+        $totalNepaliDays = $this->calculateTotalNepaliDays();
+        $this->performCalculationBasedOnNepaliDays($totalNepaliDays);
+
+        return $this->formatDateString(
+            $format,
+            $locale,
+            $this->toEnglishDateArray(),
+            $this->getTimeFormatData(),
+        );
+    }
+
     public function toEnglishDateArray(): NepaliDateArrayData
     {
         return NepaliDateArrayData::from([

--- a/src/Traits/HelperTrait.php
+++ b/src/Traits/HelperTrait.php
@@ -153,7 +153,7 @@ trait HelperTrait
         ];
     }
 
-    private function formatDateString(string $format, string $locale, $dateArray): string
+    private function formatDateString(string $format, string $locale, $dateArray, array $extraFormatData = []): string
     {
         $formattedArray = ($locale === 'en')
             ? $this->getEnglishLocaleFormattingCharacters($dateArray)
@@ -171,6 +171,7 @@ trait HelperTrait
             'D' => $formattedArray['D'],
             'S' => $formattedArray['j'],
         ];
+        $formatData = array_merge($formatData, $extraFormatData);
 
         return $this->getFormattedString($format, $formatData, $locale);
     }

--- a/src/Traits/NepaliDateTrait.php
+++ b/src/Traits/NepaliDateTrait.php
@@ -102,6 +102,19 @@ trait NepaliDateTrait
         return $this->toFormattedNepaliDate($format, $locale);
     }
 
+    public function toNepaliDateTime(string $format = 'Y-m-d H:i:s', ?string $locale = null): string
+    {
+        $locale = $locale ?? config('nepali-date.default_locale');
+        $this->performCalculationOnEnglishDate();
+
+        return $this->formatDateString(
+            $format,
+            $locale,
+            $this->toNepaliDateArrayData(),
+            $this->getTimeFormatData(),
+        );
+    }
+
     public function toFormattedNepaliDate(?string $format = null, ?string $locale = null): string
     {
         $format = $format ?? config('nepali-date.default_format');

--- a/tests/NowTodayTimeTest.php
+++ b/tests/NowTodayTimeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Anuzpandey\LaravelNepaliDate\LaravelNepaliDate;
+
+it('preserves time when converting english date time to nepali', function () {
+    $result = LaravelNepaliDate::from('1996-04-22 12:30:15', format: 'Y-m-d H:i:s')
+        ->toNepaliDateTime('Y-m-d H:i:s', 'en');
+
+    expect($result)->toBe('2053-01-10 12:30:15');
+});
+
+it('preserves time when converting nepali date time to english', function () {
+    $result = LaravelNepaliDate::from('2053-01-10 12:30:15', format: 'Y-m-d H:i:s', calendar: 'np')
+        ->toEnglishDateTime('Y-m-d H:i:s', 'en');
+
+    expect($result)->toBe('1996-04-22 12:30:15');
+});
+
+it('defaults time to midnight when input has no time component', function () {
+    $result = LaravelNepaliDate::from('1996-04-22')->toNepaliDateTime('H:i:s', 'en');
+
+    expect($result)->toBe('00:00:00');
+});
+
+it('keeps time numeric even for nepali locale output', function () {
+    $result = LaravelNepaliDate::from('1996-04-22 09:08:07', format: 'Y-m-d H:i:s')
+        ->toNepaliDateTime('Y-m-d H:i:s', 'np');
+
+    expect($result)->toBe('२०५३-०१-१० 09:08:07');
+});
+
+it('returns today for english calendar with midnight time', function () {
+    config()->set('app.timezone', 'UTC');
+    $today = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d');
+
+    $instance = LaravelNepaliDate::today('en');
+
+    expect($instance->toNepaliDate('Y-m-d', 'en'))->toBe(LaravelNepaliDate::from($today)->toNepaliDate('Y-m-d', 'en'));
+    expect($instance->toNepaliDateTime('H:i:s', 'en'))->toBe('00:00:00');
+});
+
+it('returns today for nepali calendar with midnight time', function () {
+    config()->set('app.timezone', 'UTC');
+
+    $instance = LaravelNepaliDate::today('np');
+
+    expect($instance->toEnglishDateTime('H:i:s', 'en'))->toBe('00:00:00');
+});
+
+it('returns now for english calendar with time-of-day', function () {
+    config()->set('app.timezone', 'UTC');
+
+    $instance = LaravelNepaliDate::now('en');
+
+    expect($instance->toNepaliDateTime('H:i:s', 'en'))->toMatch('/^\d{2}:\d{2}:\d{2}$/');
+});
+
+it('returns now for nepali calendar with time-of-day', function () {
+    config()->set('app.timezone', 'UTC');
+
+    $instance = LaravelNepaliDate::now('np');
+
+    expect($instance->toEnglishDateTime('H:i:s', 'en'))->toMatch('/^\d{2}:\d{2}:\d{2}$/');
+});


### PR DESCRIPTION
This PR adds current-date helpers and datetime-aware calendar conversion.

  - Adds LaravelNepaliDate::today($calendar) and LaravelNepaliDate::now($calendar)
  - Adds toNepaliDateTime() and toEnglishDateTime() with time preservation
  - Extends parsing to support date+time inputs across supported input types
  - Adds time format tokens: H, G, h, g, i, s, a, A
  - Includes tests for now/today behavior, time preservation, and parsing
  - Updates README with docs for flexible inputs, strict validation, and datetime usage